### PR TITLE
Typing, Incorrect URLs and Docs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,17 +60,17 @@ from pyneuphonic import Neuphonic
 import os
 
 client = Neuphonic(api_key=os.environ.get('NEUPHONIC_API_TOKEN'))
-voices = client.voices.get()  # get's all available voices
+response = client.voices.get()  # get's all available voices
+voices = response.data['voices']
 
-for voice in voices:
-    print(voice)
+voices
 ```
 
 #### Get Voice
 To get information about an existing voice please call.
-```
-voice = client.voices.voice(voice_id=XXX)  # Gets information about the selected voice id
-print(voice) # Response contains all information about this voice
+```python
+response = client.voices.voice(voice_id='<VOICE_ID>')  # Gets information about the selected voice id
+response.data  # Response contains all information about this voice
 ```
 
 
@@ -84,66 +84,73 @@ import os
 
 client = Neuphonic(api_key=os.environ.get('NEUPHONIC_API_TOKEN'))
 
-voice_file_path = 'XXX.wav'
+response = client.voices.clone(
+    voice_name='<VOICE_NAME>',
+    voice_tags=['tag1', 'tag2'],  # optional, add descriptive tags of what your voice sounds like
+    voice_file_path='<FILE_PATH>.wav'  # replace with file path to a sample of the voice to clone
+)
 
-result = client.voices.clone(voice_name='NewNeuphonic', voice_tags=['tag1', 'tag2'], voice_file_path=voice_file_path)
-
-print(result['data']['message'])
-
+response.data  # this will contain a success message with the voice_id of the cloned voice
 ```
 
-If you have successfully cloned a voice, the following message will be displayed: "Voice has successfully been cloned with ID XXXXXXX." Once cloned, you can use this voice just like any of the standard voices when calling the TTS (Text-to-Speech) service.
+If you have successfully cloned a voice, the following message will be displayed: "Voice has
+successfully been cloned with ID <VOICE_ID>." Once cloned, you can use this voice just like any of
+the standard voices when calling the TTS (Text-to-Speech) service.
 
-To view a list of all available voices (including the voices you have cloned), simply call the `client.voices.get(api_key="")` endpoint.
+To see a list of all available voices, including cloned ones, use `client.voices.get()` as shown in
+the example a few sections above.
 
-**Note:** Your voice reference clip must meet the following criteria: it should be at least 6 seconds long, in .mp3 or .wav format, and no larger than 10 MB in size.
+**Note:** Your voice reference clip must meet the following criteria: it should be at least 6
+seconds long, in .mp3 or .wav format, and no larger than 10 MB in size.
 
 #### Update Voice
 
-You can update the reference clip, the voice name and the tags for the user.
-You have to feed in one or multiple of voice name (`new_voice_name`),
-file_path (`new_voice_file_path`) and tags (`new_voice_tags`, `remove_voice_tags`) for the voice to be updated accordingly.
-
-Update based on the new clip and the old name:
+You can update any of the attributes of a voice: name, tags and the reference audio file the voice
+was cloned on.
+You can select which voice to update using either it's `voice_id` or it's name.
 
 ```python
-result = client.voices.update(voice_name='NewNeuphonic', ...)
+# Updating using the original voice's name
+response = client.voices.update(
+    voice_name='<ORIGINAL_VOICE_NAME>',  # this is the name of voice we want to update
 
-print(result)
+    # Provide any, or all of the following, to update the voice
+    new_voice_name='<NEW_VOICE_NAME>',
+    new_voice_tags=['new_tag_1', 'new_tag_2'],  # overwrite all previous tags
+    new_voice_file_path='<NEW_FILE_PATH>.wav',
+)
+
+response.data
 ```
 
-Alternatively, if you wanna provide the voice id:
 ```python
-result = client.voices.update(voice_id=XXX, ...)
+# Updating using the original voice's `voice_id`
+response = client.voices.update(
+    voice_id ='<VOICE_ID>',  # this is the id of voice we want to update
 
-print(result)
+    # Provide any, or all of the following, to update the voice
+    new_voice_name='<NEW_VOICE_NAME>',
+    new_voice_tags=['new_tag_1', 'new_tag_2'],  # overwrite all previous tags
+    new_voice_file_path='<NEW_FILE_PATH>.wav',
+)
+
+response.data
 ```
-
-You can feed in your desired update in these attributes:
-- `new_voice_name` = 'NewNeuphonic'
-- `new_voice_file_path` = ...
-- `new_voice_tags`=["new-tag1", ..., "new-tag2"] - Overwrites all preexisting voice tags
-
 
 **Note:** Your voice reference clip must meet the following criteria: it should be at least 6 seconds long, in .mp3 or .wav format, and no larger than 10 MB in size.
 
 #### Delete Voice
-
-To delete a voice which already exists.
+To delete a cloned voice:
 
 ```python
-
-result = client.voices.delete(voice_name='NewNeuphonic')
-
-print(result)
+# Delete using the voice's name
+response = client.voices.delete(voice_name='<VOICE_NAME>')
+response.data
 ```
-
-Alternatively, if you wanna provide the voice id:
-
 ```python
-result = client.voices.delete(voice_id=XXX)
-
-print(result)
+# Delete using the voices `voice_id`
+response = client.voices.delete(voice_id='<VOICE_ID>')
+response.data
 ```
 
 ### Audio Generation
@@ -333,7 +340,7 @@ async def main():
         name='Agent 1',
         prompt='You are a helpful agent. Answer in 10 words or less.',
         greeting='Hi, how can I help you today?'
-    )['data']['id']
+    ).data['id']
 
     agent = Agent(client, agent_id=agent_id, tts_model='neu_hq')
 

--- a/pyneuphonic/_agents.py
+++ b/pyneuphonic/_agents.py
@@ -3,13 +3,14 @@ import httpx
 
 from pyneuphonic._endpoint import Endpoint
 from pyneuphonic._websocket import AsyncAgentWebsocketClient
+from pyneuphonic.models import APIResponse, AgentObject  # noqa: F401
 
 
 class Agents(Endpoint):
     def get(
         self,
         agent_id: Optional[str] = None,
-    ):
+    ) -> APIResponse[dict]:
         """
         List created agents.
 
@@ -20,6 +21,11 @@ class Agents(Endpoint):
         ----------
         agent_id
             The ID of the agent to fetch. If None, fetches all agents.
+
+        Returns
+        -------
+        APIResponse[dict]
+            response.data['agent'] will be an object of type AgentObject.
 
         Raises
         ------
@@ -34,14 +40,14 @@ class Agents(Endpoint):
 
         self.raise_for_status(response=response, message='Failed to fetch agents.')
 
-        return response.json()
+        return APIResponse(**response.json())
 
     def create(
         self,
         name: str,
         prompt: Optional[str] = None,
         greeting: Optional[str] = None,
-    ) -> dict:
+    ) -> APIResponse[dict]:
         """
         Create a new agent.
 
@@ -53,6 +59,11 @@ class Agents(Endpoint):
             The prompt for the agent.
         greeting
             The initial greeting message for the agent.
+
+        Returns
+        -------
+        APIResponse[dict]
+            response.data will contain a success message on successful creation.
 
         Raises
         ------
@@ -74,12 +85,12 @@ class Agents(Endpoint):
 
         self.raise_for_status(response=response, message='Failed to create agent.')
 
-        return response.json()
+        return APIResponse(**response.json())
 
     def delete(
         self,
         agent_id: str,
-    ):
+    ) -> APIResponse[dict]:
         """
         Delete an agent.
 
@@ -87,6 +98,11 @@ class Agents(Endpoint):
         ----------
         agent_id : str
             The ID of the agent to delete.
+
+        Returns
+        -------
+        APIResponse[dict]
+            response.data will contain a delete message on successful deletion.
 
         Raises
         ------
@@ -101,7 +117,7 @@ class Agents(Endpoint):
 
         self.raise_for_status(response=response, message='Failed to delete agent.')
 
-        return response.json()
+        return APIResponse(**response.json())
 
     def AsyncWebsocketClient(self):
         return AsyncAgentWebsocketClient(api_key=self._api_key, base_url=self._base_url)

--- a/pyneuphonic/_voices.py
+++ b/pyneuphonic/_voices.py
@@ -1,14 +1,20 @@
-from typing import List
+from typing import List, Optional
 
 import httpx
 
 from ._endpoint import Endpoint
-from .models import VoicesResponse, VoiceItem
+from .models import APIResponse, VoiceObject  # noqa: F401
 
 
 class Voices(Endpoint):
-    def get(self) -> List[VoiceItem]:
-        """List all the voices."""
+    def get(self) -> APIResponse[dict]:
+        """Lists all voices in your voice library.
+
+        Returns
+        -------
+        APIResponse[dict]
+            response.data['voices'] will be a list of VoiceObject objects.
+        """
         response = httpx.get(
             f'{self.http_url}/voices',
             headers=self.headers,
@@ -22,11 +28,9 @@ class Voices(Endpoint):
                 response=response,
             )
 
-        voice_response = VoicesResponse(**response.json())
+        return APIResponse(**response.json())
 
-        return voice_response.data.voices
-
-    def voice(self, voice_id: str = None, voice_name: str = None):
+    def voice(self, voice_id: str = None, voice_name: str = None) -> APIResponse[dict]:
         """Get information about specific voice.
 
         Parameters
@@ -38,8 +42,8 @@ class Voices(Endpoint):
 
         Returns
         -------
-        dict
-            A dictionary with the response data from the API.
+        APIResponse[dict]
+            response.data['voice'] will be a single VoiceObject object.
 
         Raises
         ------
@@ -75,11 +79,11 @@ class Voices(Endpoint):
                 response=response,
             )
 
-        return response.json()
+        return APIResponse(**response.json())
 
     def clone(
         self, voice_name: str, voice_file_path: str, voice_tags: List[str] = []
-    ) -> dict:
+    ) -> APIResponse[dict]:
         """
         Clone a voice by uploading a file with the specified name and tags.
 
@@ -94,8 +98,8 @@ class Voices(Endpoint):
 
         Returns
         -------
-        dict
-            A dictionary with the response data from the API.
+        APIResponse[dict]
+            response.data will contain a success message with voice_id of the cloned voice.
 
         Raises
         ------
@@ -131,7 +135,7 @@ class Voices(Endpoint):
             )
 
         # Return the JSON response content as a dictionary
-        return response.json()
+        return APIResponse(**response.json())
 
     def update(
         self,
@@ -139,22 +143,27 @@ class Voices(Endpoint):
         voice_id: str = None,
         voice_name: str = None,
         new_voice_name: str = '',
-        new_voice_tags: list[str] = None,
-    ) -> dict:
+        new_voice_tags: Optional[List[str]] = None,
+    ) -> APIResponse[dict]:
         """
         Update a voice by its ID or name.
 
         Parameters
         ----------
         voice_id : str
-            The ID of the voice to be deleted.
+            The ID of the voice to update.
         voice_name : str
-            The name of the voice to be deleted.
+            The name of the voice to update. This does not need to be provided if voice_id
+            is provided.
+        new_voice_name: str
+            The new name updated name for the voice.
+        new_voice_tags: Optional[List[str]]
+            The new tags for the voice.
 
         Returns
         -------
-        dict
-            A dictionary with the response data from the API.
+        APIResponse[dict]
+            response.data will contain a success message with the updated fields of the voice.
 
         Raises
         ------
@@ -215,9 +224,9 @@ class Voices(Endpoint):
             )
 
         # Return the JSON response content as a dictionary
-        return response.json()
+        return APIResponse(**response.json())
 
-    def delete(self, voice_id: str = None, voice_name=None) -> dict:
+    def delete(self, voice_id: str = None, voice_name=None) -> APIResponse[dict]:
         """
         Delete a voice by its ID.
 
@@ -228,8 +237,8 @@ class Voices(Endpoint):
 
         Returns
         -------
-        dict
-            A dictionary with the response data from the API.
+        APIResponse[dict]
+            response.data will contain a success message with the updated fields of the voice.
 
         Raises
         ------
@@ -266,4 +275,4 @@ class Voices(Endpoint):
             )
 
         # Return the JSON response content as a dictionary
-        return response.json()
+        return APIResponse(**response.json())

--- a/pyneuphonic/_voices.py
+++ b/pyneuphonic/_voices.py
@@ -30,6 +30,28 @@ class Voices(Endpoint):
 
         return APIResponse(**response.json())
 
+    def _get_voice_id_from_name(self, voice_name) -> str:
+        """Gets the voice_id given a voice name.
+
+        Parameters
+        ----------
+        voice_name : str
+            The name of the voice to retrieve the voice_id for.
+
+        Raises
+        ------
+        ValueError
+            Raised if there is no voice with the provided name.
+        """
+        response = self.get()
+        voices = response.data['voices']
+
+        try:
+            # extract the voice_id for the requested voice from the list of all voices
+            return next(voice['id'] for voice in voices if voice['name'] == voice_name)
+        except StopIteration as e:
+            raise ValueError(f'No voice found with the name {voice_name}.')
+
     def voice(self, voice_id: str = None, voice_name: str = None) -> APIResponse[dict]:
         """Get information about specific voice.
 
@@ -53,18 +75,7 @@ class Voices(Endpoint):
 
         # Accept case if user only provide name
         if not voice_id:
-            # Get all voices for this user
-            voices = self.get()
-            try:
-                # Fetch voice id
-                voice_id = next(
-                    voice.id for voice in voices if voice.name == voice_name
-                )
-
-            except StopIteration as e:
-                raise ValueError(
-                    f'No voice found with the name {voice_name}. You cannot update this voice.'
-                )
+            voice_id = self._get_voice_id_from_name(voice_name=voice_name)
 
         response = httpx.get(
             f'{self.http_url}/voices/{voice_id}',
@@ -139,9 +150,9 @@ class Voices(Endpoint):
 
     def update(
         self,
-        new_voice_file_path: str = None,
-        voice_id: str = None,
-        voice_name: str = None,
+        voice_id: Optional[str] = None,
+        voice_name: Optional[str] = None,
+        new_voice_file_path: Optional[str] = None,
         new_voice_name: str = '',
         new_voice_tags: Optional[List[str]] = None,
     ) -> APIResponse[dict]:
@@ -150,11 +161,13 @@ class Voices(Endpoint):
 
         Parameters
         ----------
-        voice_id : str
+        voice_id : Optional[str]
             The ID of the voice to update.
-        voice_name : str
+        voice_name : Optional[str]
             The name of the voice to update. This does not need to be provided if voice_id
             is provided.
+        new_voice_file_path: Optional[str]
+            The file path for the new audio file to use for the cloned voice.
         new_voice_name: str
             The new name updated name for the voice.
         new_voice_tags: Optional[List[str]]
@@ -174,15 +187,9 @@ class Voices(Endpoint):
 
         # Accept case if user only provide name
         if not voice_id:
-            # Get all voices for this user
-            voices = self.get()
             try:
-                # Fetch voice id
-                voice_id = next(
-                    voice.id for voice in voices if voice.name == voice_name
-                )
-
-            except StopIteration as e:
+                voice_id = self._get_voice_id_from_name(voice_name=voice_name)
+            except ValueError as e:
                 raise ValueError(
                     f'No voice found with the name {voice_name}. You cannot update this voice.'
                 )
@@ -208,7 +215,7 @@ class Voices(Endpoint):
 
         # Call API
         response = httpx.patch(
-            f'{self.http_url}/voices?voice_id={voice_id}&new_voice_name={new_voice_name}',
+            f'{self.http_url}/voices/{voice_id}?new_voice_name={new_voice_name}',
             params=params,
             headers=self.headers,
             timeout=self.timeout,
@@ -247,21 +254,15 @@ class Voices(Endpoint):
             permissions to delete the voice.
         """
         if not voice_id:
-            # Get all voices for this user
-            voices = self.get()
             try:
-                # Fetch voice id
-                voice_id = next(
-                    voice.id for voice in voices if voice.name == voice_name
-                )
-
-            except StopIteration as e:
+                voice_id = self._get_voice_id_from_name(voice_name=voice_name)
+            except ValueError as e:
                 raise ValueError(
                     f'No voice found with the name {voice_name}. You cannot Delete this voice.'
                 )
 
         response = httpx.delete(
-            f'{self.http_url}/voices?voice_id={voice_id}',
+            f'{self.http_url}/voices/{voice_id}',
             headers=self.headers,
             timeout=self.timeout,
         )

--- a/pyneuphonic/models.py
+++ b/pyneuphonic/models.py
@@ -108,7 +108,7 @@ class TTSConfig(BaseConfig):
     language_id: str = Field(
         default='en',
         description=('Language id for the desired language.'),
-        example=['en'],
+        examples=['en'],
     )
 
     voice: Optional[str] = Field(

--- a/pyneuphonic/models.py
+++ b/pyneuphonic/models.py
@@ -6,7 +6,7 @@ from typing import Generic, TypeVar
 
 
 def to_dict(model: BaseModel):
-    """Returns a pydantic model as dict, with all of the None items removed."""
+    """Returns a pydantic model as a dictionary, excluding items with None values."""
     return {k: v for k, v in model.model_dump().items() if v is not None}
 
 
@@ -17,29 +17,27 @@ class BaseConfig(BaseModel):
     model_config = ConfigDict(extra='allow')
 
     def to_query_params(self) -> str:
-        """Generate a query params string from the AgentConfig object, dropping None values."""
+        """Generate a query parameter string from the object, excluding None values."""
         params = to_dict(self)
         return '&'.join(f'{key}={value}' for key, value in params.items())
 
 
 class AgentConfig(BaseConfig):
     """
-    API parameters passed to the /agent endpoint.
+    API parameters for the /agent endpoint.
     """
 
     agent_id: Optional[str] = Field(
         default=None,
-        description='Id of selected agent. If none, then a default agent will be used.',
-        examples=[
-            'da78ea32-9225-436e-b10d-d5b101bb01a6'
-        ],  # note - this is not a real agent_id
+        description='ID of the selected agent. If None, a default agent will be used.',
+        examples=['da78ea32-9225-436e-b10d-d5b101bb01a6'],  # example agent_id
     )
 
     endpointing: Optional[float] = Field(
         default=None,
         description=(
-            'This is how long (in milliseconds) the speech recognition program will listen for '
-            'silence in the recieved audio until it decides that the user is finished speaking.'
+            'Duration (in milliseconds) the speech recognition program will listen for '
+            'silence in the received audio before concluding the user has finished speaking.'
         ),
         examples=[50, 100, 1000],
     )
@@ -47,9 +45,8 @@ class AgentConfig(BaseConfig):
     mode: Optional[str] = Field(
         default='asr-llm-tts',
         description=(
-            'This option decides how you want to use the agent. `asr-llm-tts` option indicates that '
-            'you want to do audio in, audio out. `llm-tts` indicates that you want to do text in, '
-            'audio out.'
+            'Mode of agent usage. `asr-llm-tts` indicates audio input and output. '
+            '`llm-tts` indicates text input and audio output.'
         ),
         examples=['asr-llm-tts', 'llm-tts'],
     )
@@ -59,7 +56,7 @@ class AgentConfig(BaseConfig):
     incoming_sampling_rate: Optional[int] = Field(
         default=16000,
         description=(
-            'Sampling rate of the audio sent to the server. Lower sampling raes will generally '
+            'Sampling rate of the audio sent to the server. Lower rates generally '
             'yield faster transcription.'
         ),
         examples=[8000, 16000, 22050],
@@ -86,16 +83,18 @@ class AgentConfig(BaseConfig):
 
 class TTSConfig(BaseConfig):
     """
-    Model parameters passed to the text to speech endpoints.
+    Model parameters for the text-to-speech endpoints.
     """
 
     speed: Optional[float] = Field(
-        default=1.0, description='Playback speed of audio.', examples=[0.7, 1.0, 1.5]
+        default=1.0,
+        description='Playback speed of the audio.',
+        examples=[0.7, 1.0, 1.5],
     )
 
     temperature: Optional[float] = Field(
         default=None,
-        description='Randomness introduced into the text-to-speech model. Ranges from 0 to 1.0.',
+        description='Randomness introduced into the text-to-speech model. Range: 0 to 1.0.',
         examples=[0.5, 0.7],
     )
 
@@ -107,14 +106,14 @@ class TTSConfig(BaseConfig):
 
     language_id: str = Field(
         default='en',
-        description=('Language id for the desired language.'),
+        description='Language ID for the desired language.',
         examples=['en'],
     )
 
     voice: Optional[str] = Field(
         default=None,
         description=(
-            'The voice_id for the desired voice. Ensure that this voice_id is available for the '
+            'The voice ID for the desired voice. Ensure this voice ID is available for the '
             'selected model.'
         ),
         examples=['8e9c4bc8-3979-48ab-8626-df53befc2090'],
@@ -134,30 +133,30 @@ class TTSConfig(BaseConfig):
 
 
 class APIResponse(BaseModel, Generic[T]):
-    """All responses from the API will be typed with this pydantic model."""
+    """All API responses will be typed with this pydantic model."""
 
     model_config = ConfigDict(extra='allow')
 
     data: Optional[T] = Field(
         default=None,
-        description='API response data. This will contain data on a succesful response.',
+        description='API response data. Contains data on a successful response.',
     )
 
     metadata: Optional[dict] = Field(
         default=None,
         description=(
-            'Additional metadata from the API. This will include pagination metadata for paginated '
+            'Additional metadata from the API. Includes pagination metadata for paginated '
             'endpoints.'
         ),
     )
 
     """
-    The below two fields only exist for responses from SSE endpoints.
+    The following fields are only for responses from SSE endpoints.
     """
     status_code: Optional[int] = Field(
         default=None,
         description=(
-            'Status code of API response. This is only set for responses on the SSE endpoints.'
+            'Status code of the API response. Only set for responses on SSE endpoints.'
         ),
         examples=[200, 400],
     )
@@ -165,7 +164,7 @@ class APIResponse(BaseModel, Generic[T]):
     errors: Optional[List[str]] = Field(
         default=None,
         description=(
-            'All errors associated with the SSE response, if the status_code is a non 2XX code.'
+            'All errors associated with the SSE response, if the status_code is non-2XX.'
         ),
     )
 
@@ -175,7 +174,7 @@ class VoiceObject(TypedDict):
 
     id: str
     """
-    The voice_id for the voice.
+    The voice ID.
     Examples: ['8e9c4bc8-3979-48ab-8626-df53befc2090']
     """
 
@@ -188,7 +187,7 @@ class VoiceObject(TypedDict):
     tags: List[str]
     """
     A list of tags describing the voice.
-    Examples: [['Male', 'American', 'Fourties', 'Narrator'], ['Female', 'British', 'Twenties', 'Excited']]
+    Examples: [['Male', 'American', 'Forties', 'Narrator'], ['Female', 'British', 'Twenties', 'Excited']]
     """
 
     model_availability: List[str]
@@ -197,13 +196,18 @@ class VoiceObject(TypedDict):
     Examples: [['neu_fast', 'neu_hq'], ['neu_hq']]
     """
 
+    standard: str
+    """
+    Indicates whether this is a standard voice provided by Neuphonic, or a cloned voice.
+    """
+
 
 class AgentObject(TypedDict):
     """TypedDict representing an agent object with its attributes."""
 
     id: str
     """
-    The agent_id for the agent.
+    The agent ID.
     Examples: ['1234abcd-5678-efgh-9101-ijklmnopqrst']
     """
 
@@ -228,7 +232,7 @@ class AgentObject(TypedDict):
 
 class AudioBaseModel(BaseModel):
     """
-    Base model for any models containg audio.
+    Base model for any models containing audio.
     """
 
     model_config = ConfigDict(extra='allow')
@@ -237,7 +241,7 @@ class AudioBaseModel(BaseModel):
         default=None,
         description=(
             'Audio received from the server. The server returns audio as a base64 encoded string, '
-            'this will be parsed into bytes by the field_validator.'
+            'which will be parsed into bytes by the field_validator.'
         ),
     )
 
@@ -255,7 +259,7 @@ class AudioBaseModel(BaseModel):
 
 
 class TTSResponse(AudioBaseModel):
-    """Structure of data received from TTS endpoints, when using any client in `Neuphonic.tts.`"""
+    """Structure of data received from TTS endpoints, when using any client in `Neuphonic.tts`."""
 
     text: Optional[str] = Field(
         default=None, description='Text corresponding to the audio snippet.'
@@ -272,21 +276,20 @@ class AgentResponse(AudioBaseModel):
     """Structure of data received from Agent endpoints, when using any client in `Neuphonic.agent`."""
 
     type: str = Field(
-        description='Which type of message is being sent the server',
+        description='Type of message being sent by the server',
         examples=['llm_response', 'audio_response', 'user_transcript'],
     )
 
     text: Optional[str] = Field(
         default=None,
         description=(
-            'This will contain the corresponding text if the `type` is `llm_response` or '
-            '`user_transcript`.'
+            'Corresponding text if the `type` is `llm_response` or `user_transcript`.'
         ),
     )
 
 
 class WebsocketEvents(Enum):
-    """Enum describing all of the valid websocket events that callbacks can be bound to."""
+    """Enum describing all valid websocket events that callbacks can be bound to."""
 
     OPEN: str = 'open'
     MESSAGE: str = 'message'

--- a/pyneuphonic/models.py
+++ b/pyneuphonic/models.py
@@ -88,7 +88,7 @@ class TTSConfig(BaseConfig):
     )
 
     temperature: Optional[float] = Field(
-        deafult=None,
+        default=None,
         description='Randomness introduced into the text-to-speech model. Ranges from 0 to 1.0.',
         examples=[0.5, 0.7],
     )
@@ -106,7 +106,7 @@ class TTSConfig(BaseConfig):
     )
 
     voice: Optional[str] = Field(
-        deafult=None,
+        default=None,
         description=(
             'The voice_id for the desired voice. Ensure that this voice_id is available for the '
             'selected model.'

--- a/pyneuphonic/models.py
+++ b/pyneuphonic/models.py
@@ -301,20 +301,3 @@ class WebsocketEventHandlers(BaseModel):
     message: Optional[Callable[[APIResponse[T]], Awaitable[None]]] = None
     close: Optional[Callable[[], Awaitable[None]]] = None
     error: Optional[Callable[[Exception], Awaitable[None]]] = None
-
-
-# --- Deprecated ---
-class WebsocketResponse(BaseModel):
-    """DEPRECATED. Structure of responses when using AsyncWebsocketClient"""
-
-    model_config = ConfigDict(extra='allow')
-    data: TTSResponse
-
-
-class SSEResponse(BaseModel):
-    """DEPRECATED. Structure of response when using SSEClient or AsyncSSEClient."""
-
-    model_config = ConfigDict(extra='allow')
-
-    status_code: int
-    data: TTSResponse

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # POETRY CONFIG
 [tool.poetry]
 name = "pyneuphonic"
-version = "1.5.0"
+version = "1.5.1"
 description = "A python SDK for the Neuphonic TTS Engine."
 authors = ["Neuphonic <support@neuphonic.com>"]
 readme = "README.md"

--- a/snippets/sse/simple_tts.py
+++ b/snippets/sse/simple_tts.py
@@ -20,9 +20,7 @@ async def main():
                 break
 
             response = sse.send(user_text)
-
-            for item in response:
-                player.play(item.data.audio)
+            player.play(response)
 
 
 if __name__ == '__main__':

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -81,7 +81,8 @@ async def test_websocket_async(client):
 
 
 def test_get_voices(client):
-    voices = client.voices.get()
+    response = client.voices.get()
+    voices = response.data['voices']
 
     assert len(voices) > 0
 

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,5 +1,5 @@
 import pytest
-from pyneuphonic.models import APIResponse, WebsocketEvents, VoiceItem, TTSResponse
+from pyneuphonic.models import APIResponse, WebsocketEvents, TTSResponse, VoiceObject
 from pyneuphonic import save_audio
 import asyncio
 import os
@@ -86,7 +86,8 @@ def test_get_voices(client):
     assert len(voices) > 0
 
     for voice in voices:
-        assert isinstance(voice, VoiceItem)
+        assert isinstance(voice, dict)
+        assert all(key in voice for key in VoiceObject.__annotations__.keys())
 
 
 @pytest.mark.asyncio

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -6,7 +6,7 @@ from pytest_mock import MockerFixture
 from pydantic import BaseModel
 import uuid
 from pyneuphonic import Neuphonic, TTSConfig
-from pyneuphonic.models import VoiceItem, APIResponse, TTSResponse, to_dict
+from pyneuphonic.models import APIResponse, TTSResponse, VoiceObject, to_dict
 
 from unittest.mock import MagicMock
 
@@ -124,7 +124,8 @@ async def test_get_voices(client: Neuphonic, mocker: MockerFixture):
     assert len(voices) == 3
 
     for voice in voices:
-        assert isinstance(voice, VoiceItem)
+        assert isinstance(voice, dict)
+        assert all(key in voice for key in VoiceObject.__annotations__.keys())
 
 
 class CloneVoiceResponse(BaseModel):

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -3,7 +3,6 @@ import pytest
 import tempfile
 import wave
 from pytest_mock import MockerFixture
-from pydantic import BaseModel
 import uuid
 from pyneuphonic import Neuphonic, TTSConfig
 from pyneuphonic.models import APIResponse, TTSResponse, VoiceObject, to_dict
@@ -119,21 +118,16 @@ async def test_get_voices(client: Neuphonic, mocker: MockerFixture):
     mock_response.json.return_value = return_value
     mock_get = mocker.patch('httpx.get', return_value=mock_response)
 
-    voices = client.voices.get()
+    response = client.voices.get()
+    assert isinstance(response, APIResponse)
+    voices = response.data['voices']
 
     assert len(voices) == 3
 
     for voice in voices:
         assert isinstance(voice, dict)
-        assert all(key in voice for key in VoiceObject.__annotations__.keys())
-
-
-class CloneVoiceResponse(BaseModel):
-    class Data(BaseModel):
-        message: str
-        voice_id: str
-
-    data: Data
+        # assert that the response only contains valid keys, and not extra keys
+        assert all(key in VoiceObject.__annotations__.keys() for key in voice)
 
 
 @pytest.mark.asyncio
@@ -160,23 +154,21 @@ async def test_clone_voice(client: Neuphonic, mocker: MockerFixture):
 
         # Configure the mock response
         mock_response = mocker.Mock()
-        mock_response.json.return_value = {
+        return_value = {
             'data': {
                 'message': 'Voice has successfully been cloned.',
                 'voice_id': '12345',
             }
         }
+        mock_response.json.return_value = return_value
         mock_post.return_value = mock_response
 
         # Call the clone method
         response = client.voices.clone(voice_name, voice_file_path, voice_tags)
-        clone_voice_response = CloneVoiceResponse(**response)
 
         # Assertions
-        assert (
-            'Voice has successfully been cloned.' in clone_voice_response.data.message
-        )
-        assert clone_voice_response.data.voice_id == '12345'
+        assert isinstance(response, APIResponse)
+        assert return_value['data'] == response.data
 
         # Ensure httpx.post was called with correct parameters
         base_url = os.getenv('NEUPHONIC_API_URL', 'default-api-url')
@@ -211,7 +203,11 @@ def test_delete_voice(client: Neuphonic, mocker: MockerFixture):
     mock_delete = mocker.patch('httpx.delete', return_value=mock_response)
 
     # Delete Voice
-    delete_response = client.voices.delete(voice_id)
+    response = client.voices.delete(voice_id)
+
+    # Assertions
+    assert isinstance(response, APIResponse)
+    assert return_value['data'] == response.data
 
     # Assert the HTTP method and endpoint were called correctly
     base_url = os.getenv('NEUPHONIC_API_URL')
@@ -220,13 +216,6 @@ def test_delete_voice(client: Neuphonic, mocker: MockerFixture):
         headers={'x-api-key': mocker.ANY},  # Ensures api key was present
         timeout=10,
     )
-
-    # Deserialize response into the correct response model
-    delete_voice_response = CloneVoiceResponse(**delete_response)
-
-    # Check the response message
-    assert 'Voice was successfully deleted' in delete_voice_response.data.message
-    assert delete_voice_response.data.voice_id == voice_id
 
 
 # Example of a test where the HTTP post is mocked
@@ -314,14 +303,6 @@ def test_restore_get(client: Neuphonic, mocker: MockerFixture):
     assert result['status'] == 'Finished'
 
 
-class AgentResponse(BaseModel):
-    class Data(BaseModel):
-        message: str
-        id: str
-
-    data: Data
-
-
 def test_create_agent(client: Neuphonic, mocker: MockerFixture):
     mock_response = mocker.Mock()
     mock_response.is_success = True
@@ -343,10 +324,11 @@ def test_create_agent(client: Neuphonic, mocker: MockerFixture):
         'greeting': None,
     }
 
-    create_response = client.agents.create(**data)
+    response = client.agents.create(**data)
 
-    create_response = AgentResponse(**create_response)
-    assert create_response.data.id == random_uuid
+    # Assertions
+    assert isinstance(response, APIResponse)
+    assert return_value['data'] == response.data
 
     mock_create.assert_called_once_with(
         f'https://{client._base_url}/agents',
@@ -371,10 +353,11 @@ def test_delete_agent(client: Neuphonic, mocker: MockerFixture):
     mock_response.json.return_value = return_value
     mock_delete = mocker.patch('httpx.delete', return_value=mock_response)
 
-    delete_response = client.agents.delete(agent_id=random_uuid)
+    response = client.agents.delete(agent_id=random_uuid)
 
-    delete_response = AgentResponse(**delete_response)
-    assert delete_response.data.id == random_uuid
+    # Assertions
+    assert isinstance(response, APIResponse)
+    assert return_value['data'] == response.data
 
     mock_delete.assert_called_once_with(
         f'https://{client._base_url}/agents/{random_uuid}',
@@ -402,9 +385,11 @@ def test_list_agents(client: Neuphonic, mocker: MockerFixture):
     mock_response.json.return_value = return_value
     mock_get = mocker.patch('httpx.get', return_value=mock_response)
 
-    get_response = client.agents.get()
-    assert get_response['data']['agents'][0]['id'] == random_uuid_1
-    assert get_response['data']['agents'][1]['id'] == random_uuid_2
+    response = client.agents.get()
+
+    # Assertions
+    assert isinstance(response, APIResponse)
+    assert return_value['data'] == response.data
 
     mock_get.assert_called_once_with(
         f'https://{client._base_url}/agents',
@@ -432,8 +417,11 @@ def test_list_single_agent(client: Neuphonic, mocker: MockerFixture):
     mock_response.json.return_value = return_value
     mock_get = mocker.patch('httpx.get', return_value=mock_response)
 
-    get_response = client.agents.get(agent_id=random_uuid)
-    assert get_response['data']['agent']['id'] == random_uuid
+    response = client.agents.get(agent_id=random_uuid)
+
+    # Assertions
+    assert isinstance(response, APIResponse)
+    assert return_value['data'] == response.data
 
     mock_get.assert_called_once_with(
         f'https://{client._base_url}/agents/{random_uuid}',

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -212,7 +212,7 @@ def test_delete_voice(client: Neuphonic, mocker: MockerFixture):
     # Assert the HTTP method and endpoint were called correctly
     base_url = os.getenv('NEUPHONIC_API_URL')
     mock_delete.assert_called_once_with(
-        f'https://{base_url}/voices?voice_id={voice_id}',
+        f'https://{base_url}/voices/{voice_id}',
         headers={'x-api-key': mocker.ANY},  # Ensures api key was present
         timeout=10,
     )


### PR DESCRIPTION
Cleaning up the use of `pydantic` and general typing in `pyneuphonic`

**Done**
- `pyneuphonic/models.py` - removed un-used `pydantic` models. Added some `TypedDicts` for agent and voice objects. Added more docstrings.
- Wrapped all API responses (except `/restore`) in the `APIResponse` model.
- Updated all tests and README accordingly.
- Fixed incorrect URLs for `PATCH /voices/{voice_id}`, `DELETE /voices/{voice_id}`