### PR TITLE
`AgentConfig` update

### DIFF
--- a/pyneuphonic/agents.py
+++ b/pyneuphonic/agents.py
@@ -52,7 +52,7 @@ class Agent:
         if 'asr' in self.config.mode:
             # passing in the websocket object will automatically forward audio to the server
             self.recorder = AsyncAudioRecorder(
-                sampling_rate=self.config.sampling_rate,
+                sampling_rate=self.config.incoming_sampling_rate,
                 websocket=self.ws,
                 player=self.player,
             )

--- a/pyneuphonic/models.py
+++ b/pyneuphonic/models.py
@@ -66,7 +66,7 @@ class AgentConfig(BaseConfig):
         examples=[8000, 16000, 22050],
     )
 
-    outgoing_sampling_rate: Optional[int] = Field(
+    return_sampling_rate: Optional[int] = Field(
         default=22050,
         description='Sampling rate of the audio returned from the server.',
         examples=[8000, 16000, 22050],
@@ -78,7 +78,7 @@ class AgentConfig(BaseConfig):
         examples=['pcm_linear', 'pcm_mulaw'],
     )
 
-    outgoing_encoding: Optional[str] = Field(
+    return_encoding: Optional[str] = Field(
         default='pcm_linear',
         description='Encoding of the audio returned from the server.',
         examples=['pcm_linear', 'pcm_mulaw'],

--- a/pyneuphonic/models.py
+++ b/pyneuphonic/models.py
@@ -33,6 +33,12 @@ class AgentConfig(BaseConfig):
         examples=['da78ea32-9225-436e-b10d-d5b101bb01a6'],  # example agent_id
     )
 
+    tts_model: Optional[str] = Field(
+        default=None,
+        description='The Neuphonic model to be used for text-to-speech synthesis.',
+        examples=['neu_fast', 'neu_hq'],
+    )
+
     endpointing: Optional[float] = Field(
         default=None,
         description=(
@@ -50,8 +56,6 @@ class AgentConfig(BaseConfig):
         ),
         examples=['asr-llm-tts', 'llm-tts'],
     )
-
-    sampling_rate: int = 16000
 
     incoming_sampling_rate: Optional[int] = Field(
         default=16000,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # POETRY CONFIG
 [tool.poetry]
 name = "pyneuphonic"
-version = "1.5.3"
+version = "1.5.4"
 description = "A python SDK for the Neuphonic TTS Engine."
 authors = ["Neuphonic <support@neuphonic.com>"]
 readme = "README.md"


### PR DESCRIPTION
**Bug fixes**
- Renamed two parameters on `AgentConfig` as they were incorrect. `outgoing_sampling_rate` -> `return_sampling_rate` and `outgoing_encoding` -> `return_encoding`.

**Refactors**
- Removed deprecated `sampling_rate` parameter on `AgentConfig`. Users should use `return_sampling_rate` and `return_sampling_rate`.
- Added `tts_model` attribute to the `AgentConfig`, forgot to add this last time. Doesn't cause any errors if its not on the class but should be there for documentation.

