### PR TITLE
Loosen restriction on websockets package.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 python = "^3.9"
-websockets = "^12.0"
+websockets = ">=12.0,<14.0"
 certifi = "^2024.0.0"
 pydantic = "^2.9.2"
 httpx = "^0.27.2"


### PR DESCRIPTION
Loosen restriction on `websockets` package to avoid version conflicts when using `pyneuphonic` within `pipecat` SDK. `pipecat` TTS integrations require `"websockets~=13.1"` which causes issues when trying to install `pyneuphonic` within a `pipecat` project that uses other TTS services as well.

All tests pass.
Manual tests also show no issues.