### PR TITLE
Add interruption handling for agent.

### DIFF
--- a/examples/websocket/speech_to_speech.py
+++ b/examples/websocket/speech_to_speech.py
@@ -30,6 +30,9 @@ async def main():
             await player.play(message.data.audio)
         elif message.data.type == 'user_transcript':
             print(f'User: {message.data.text}')
+            await (
+                player.stop_playback()
+            )  # stops playback, and allows for user to interrupt
         elif message.data.type == 'llm_response':
             print(f'Agent: {message.data.text}')
 

--- a/pyneuphonic/__init__.py
+++ b/pyneuphonic/__init__.py
@@ -1,3 +1,12 @@
+import logging
+
+logger = logging.getLogger('pyneuphonic')
+logging.basicConfig(
+    format='%(asctime)s - %(levelname)s - (%(name)s) %(message)s',
+    level=logging.WARNING,
+    datefmt='%Y-%m-%d %H:%M:%S',
+)
+
 from pyneuphonic.agents import Agent
 from pyneuphonic.client import Neuphonic
 from pyneuphonic.models import TTSConfig, WebsocketEvents, AgentConfig

--- a/pyneuphonic/_restore.py
+++ b/pyneuphonic/_restore.py
@@ -95,7 +95,9 @@ class Restore(Endpoint):
             f.write(response.content)
 
     def delete(self, job_id=None) -> APIResponse[dict]:
-        response = httpx.delete(f'{self.http_url}/restore/{job_id}', headers=self.headers)
+        response = httpx.delete(
+            f'{self.http_url}/restore/{job_id}', headers=self.headers
+        )
 
         # Handle response errors
         if not response.is_success:

--- a/pyneuphonic/_utils.py
+++ b/pyneuphonic/_utils.py
@@ -4,6 +4,7 @@ from typing import Optional, Iterator, Union, AsyncIterator
 
 from pyneuphonic.models import APIResponse, TTSResponse
 
+
 def save_audio(
     audio_bytes: Union[bytes, bytearray, Iterator[APIResponse[TTSResponse]]],
     file_path: str,

--- a/pyneuphonic/agents.py
+++ b/pyneuphonic/agents.py
@@ -73,6 +73,10 @@ class Agent:
         if message.data.type == 'audio_response':
             if not self.mute:
                 await self.player.play(message.data.audio)
+        elif message.data.type == 'user_transcript':
+            # Stop any currently playing audio when user starts speaking
+            if not self.mute:
+                await self.player.stop_playback()
 
         if self.on_message_hook is not None and callable(self.on_message_hook):
             self.on_message_hook(message)

--- a/pyneuphonic/player.py
+++ b/pyneuphonic/player.py
@@ -45,7 +45,9 @@ class AudioPlayer:
         """Returns True if there is audio currently playing."""
         return time.perf_counter() < self._playback_end
 
-    def _get_default_output_device_info(self):
+    @staticmethod
+    def _get_default_output_device_info():
+        """Get the output device that pyaudio will choose by default."""
         pa = pyaudio.PyAudio()
         device_info = pa.get_default_output_device_info()
         pa.terminate()
@@ -53,7 +55,8 @@ class AudioPlayer:
 
     @property
     def output_device_possibly_has_echo(self):
-        output_device = self._get_default_output_device_info()
+        """Checks whether the default output device is likely to have echo based on naming heuristics."""
+        output_device = AudioPlayer._get_default_output_device_info()
         device_name = output_device['name'].lower()
         keywords = ['airpods', 'headphone', 'headset', 'earbuds']
 
@@ -278,7 +281,7 @@ class AsyncAudioRecorder:
             if self.player.output_device_possibly_has_echo and self.allow_interruptions:
                 logger.warning(
                     'You have set allow_interruptions=True on AsyncAudioRecorder but your output device '
-                    f'"{self.player._get_default_output_device_info()["name"]}" is not a headset. '
+                    f'"{AudioPlayer._get_default_output_device_info()["name"]}" is not a headset. '
                     'This may cause audio feedback or echo when recording while playing audio.'
                 )
             elif not self.allow_interruptions:

--- a/pyneuphonic/player.py
+++ b/pyneuphonic/player.py
@@ -7,11 +7,13 @@ from pyneuphonic._utils import save_audio
 from base64 import b64encode
 import time
 
+logger = logging.getLogger('pyneuphonic')
+
 try:
     import pyaudio
 except ModuleNotFoundError:
-    logging.warning(
-        '(pyneuphonic) `pyaudio` is not installed, so audio playback and audio recording'
+    logger.warning(
+        '`pyaudio` is not installed, so audio playback and audio recording'
         ' functionality will not be enabled, and attempting to use this functionality may'
         ' throw errors. `pip install pyaudio` to resolve. This message may be ignored if'
         ' audio playback and recording features are not required.'
@@ -42,6 +44,23 @@ class AudioPlayer:
     def is_playing(self):
         """Returns True if there is audio currently playing."""
         return time.perf_counter() < self._playback_end
+
+    def _get_default_output_device_info(self):
+        pa = pyaudio.PyAudio()
+        device_info = pa.get_default_output_device_info()
+        pa.terminate()
+        return device_info
+
+    @property
+    def output_device_possibly_has_echo(self):
+        output_device = self._get_default_output_device_info()
+        device_name = output_device['name'].lower()
+        keywords = ['airpods', 'headphone', 'headset', 'earbuds']
+
+        if any(keyword in device_name for keyword in keywords):
+            return False
+
+        return True
 
     def open(self):
         """Open the audio stream for playback. `pyaudio` must be installed."""
@@ -102,7 +121,9 @@ class AudioPlayer:
     ):
         """Saves the audio using pynuephonic.save_audio"""
         save_audio(
-            audio_bytes=self.audio_bytes, sampling_rate=self.sampling_rate, file_path=file_path
+            audio_bytes=self.audio_bytes,
+            sampling_rate=self.sampling_rate,
+            file_path=file_path,
         )
 
     def __enter__(self):
@@ -116,15 +137,47 @@ class AudioPlayer:
 
 
 class AsyncAudioPlayer(AudioPlayer):
+    """Asynchronous version of AudioPlayer that allows for smoother handling of interruptions."""
+
     def __init__(self, sampling_rate: int = 22050):
         super().__init__(sampling_rate)
+        self.playback_task: asyncio.Task | None = None
+        self.playback_queue: asyncio.Queue | None = asyncio.Queue()
 
     async def open(self):
+        """Open the audio stream for playback and creates playback task. `pyaudio` must be installed."""
         super().open()
+        self.playback_task = asyncio.create_task(self._playback_task())
 
-    async def play(self, data: Union[bytes, AsyncIterator[APIResponse[TTSResponse]]]):
+    async def _playback_task(self):
+        """The playback function that runs as a task. Grabs items off self.playback_queue and plays them using self._play."""
+        while True:
+            if isinstance(self.playback_queue, asyncio.Queue):
+                audio_chunk = await self.playback_queue.get()
+                await self._play(audio_chunk)
+            else:
+                raise Exception(
+                    f'`audio_queue` is an invalid type: {type(self.playback_queue)}'
+                )
+
+    async def _play(self, data: Union[bytes, AsyncIterator[APIResponse[TTSResponse]]]):
+        """
+        Play audio data or automatically stream over SSE responses and play the audio.
+
+        Identical to super().play.
+
+        Parameters
+        ----------
+        data : Union[bytes, Iterator[TTSResponse]]
+            The audio data to play, either as bytes or an iterator of TTSResponse.
+        """
         if isinstance(data, bytes):
-            await asyncio.to_thread(super().play, data)
+            CHUNK_SIZE = 2048  # chunked playback to allow responsive interruptions
+            for i in range(0, len(data), CHUNK_SIZE):
+                chunk = data[i : i + CHUNK_SIZE]
+                if not chunk:
+                    break
+                await asyncio.to_thread(super().play, chunk)
         elif isinstance(data, AsyncIterator):
             async for message in data:
                 if not isinstance(message, APIResponse[TTSResponse]):
@@ -139,8 +192,36 @@ class AsyncAudioPlayer(AudioPlayer):
                 '`data` must be of type bytes or an AsyncIterator of APIResponse[TTSResponse]'
             )
 
+    async def play(self, data: Union[bytes, AsyncIterator[APIResponse[TTSResponse]]]):
+        """Enqueue a chunk of audio to be picked up by self._playback_task."""
+        if isinstance(data, bytes):
+            await self.playback_queue.put(data)
+        elif isinstance(data, AsyncIterator):
+            async for message in data:
+                await self.playback_queue.put(message.data.audio)
+        else:
+            raise TypeError(
+                '`data` must be of type bytes or an AsyncIterator of APIResponse[TTSResponse]'
+            )
+
     async def close(self):
+        """Stop audio playback immediately and close all pyaudio resources."""
+        await self.stop_playback()
         super().close()
+
+    async def stop_playback(self):
+        """Stops audio playback immediately and deletes all audio that still needs to be played, if
+        the player is currently playing."""
+        if isinstance(self.playback_task, asyncio.Task) and self.is_playing:
+            try:
+                self.playback_task.cancel()
+                await self.playback_task
+            except asyncio.CancelledError as e:
+                pass
+            finally:
+                del self.playback_queue
+                self.playback_queue = asyncio.Queue()
+                self.playback_task = asyncio.create_task(self._playback_task())
 
     async def __aenter__(self):
         """Enter the runtime context related to this object."""
@@ -154,8 +235,28 @@ class AsyncAudioPlayer(AudioPlayer):
 
 class AsyncAudioRecorder:
     def __init__(
-        self, sampling_rate: int = 16000, websocket=None, player: AudioPlayer = None
+        self,
+        sampling_rate: int = 16000,
+        websocket=None,
+        player: AudioPlayer = None,
+        allow_interruptions: bool | None = None,
     ):
+        """
+        Initialize the AsyncAudioRecorder.
+
+        Parameters
+        ----------
+        sampling_rate : int, optional
+            The sampling rate for audio recording, by default 16000.
+        websocket : object, optional
+            Websocket client for sending audio data, by default None.
+        player : AudioPlayer, optional
+            Audio player instance that may be used for playback, by default None.
+        allow_interruptions : bool or None, optional
+            Whether to allow recording while playing audio, by default None and is determined based
+            on devices default output device. If the output device is a headset, then
+            allow_interruptions will be set to True as there will be no echo.
+        """
         self.p = None
         self.stream = None
         self.sampling_rate = sampling_rate
@@ -166,23 +267,47 @@ class AsyncAudioRecorder:
 
         self._tasks = []
 
+        if isinstance(player, (AudioPlayer, AsyncAudioPlayer)):
+            if allow_interruptions is None:
+                self.allow_interruptions = (
+                    not self.player.output_device_possibly_has_echo
+                )
+            else:
+                self.allow_interruptions = allow_interruptions
+
+            if self.player.output_device_possibly_has_echo and self.allow_interruptions:
+                logger.warning(
+                    'You have set allow_interruptions=True on AsyncAudioRecorder but your output device '
+                    f'"{self.player._get_default_output_device_info()["name"]}" is not a headset. '
+                    'This may cause audio feedback or echo when recording while playing audio.'
+                )
+            elif not self.allow_interruptions:
+                logger.warning(
+                    'Audio interruptions are disabled (allow_interruptions=False on AsyncAudioRecorder). '
+                    'This setting was either explicitly configured or automatically determined based on your output device. '
+                    'When audio is playing, microphone input will be disabled to prevent echo, '
+                    'meaning you cannot interrupt the agent while it is speaking.'
+                )
+
     async def _send(self):
         while True:
             try:
                 # Wait for audio data from the queue
                 data = await self._queue.get()
 
-                if self.player is not None and not self.player.is_playing:
+                if self.player is not None and (
+                    not self.player.is_playing or self.allow_interruptions
+                ):
                     await self._ws.send({'audio': b64encode(data).decode('utf-8')})
             except Exception as e:
-                logging.error(f'Error in _send: {e}')
+                logger.error(f'Error in _send: {e}')
 
     def _callback(self, in_data, frame_count, time_info, status):
         try:
             # Enqueue the incoming audio data for processing in the async loop
             self._queue.put_nowait(in_data)
         except asyncio.QueueFull:
-            logging.error('Audio queue is full! Dropping frames.')
+            logger.error('Audio queue is full! Dropping frames.')
         return None, pyaudio.paContinue
 
     async def record(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,14 @@ ignore = ["F841"]
 select = ["E4", "E7", "E9", "F", "W", "C901"]
 
 # Ignore unused-imports and wildcard * imports in __init__.py and __main__.py files.
-extend-per-file-ignores = { "**/__init__.py" = ["F401", "F403"], "**/__main__.py" = ["F401", "F403"] }
+extend-per-file-ignores = { "**/__init__.py" = [
+  "F401",
+  "F403",
+  "E402",
+], "**/__main__.py" = [
+  "F401",
+  "F403",
+] }
 
 [tool.ruff.format]
 # Override the default setting, which is "double".


### PR DESCRIPTION
This PR implements the following:
- Interruption handling for the agent. This is enabled (using a naming heuristic) for any audio device that sounds like it probably won't cause echo, and disabled by default for everything else. This can be overridden.
- Created a `pyneuphonic` logger namespace so warnings print a bit nicer.
- Added some more documentation to the code.
- `ruff format .` which formatted some unrelated files.